### PR TITLE
Avoid NoMethodfError of LockDiff.client in error message

### DIFF
--- a/lib/lock_diff/pull_request.rb
+++ b/lib/lock_diff/pull_request.rb
@@ -8,7 +8,7 @@ module LockDiff
       def find_by(repository:, number:)
         client.pull_request(repository, number)
       rescue => e
-        message = "Not found pull request by (repository: #{repository}, number: #{number}, client: #{LockDiff.client.class}). Becase of #{e.inspect}"
+        message = "Not found pull request by (repository: #{repository}, number: #{number}, client: #{client.class}). Becase of #{e.inspect}"
         LockDiff.logger.warn(message)
         raise NotFoundPullRequest.new(message)
       end


### PR DESCRIPTION
When something wrong (e.g. without GITHUB_ACCESS_TOKEN environment variable) it will raise NotFoundPullRequest, but error message raises NoMethodError in `LockDiff.client`.
