### PR TITLE
Fix regular expression

### DIFF
--- a/lib/lock_diff/github/repository_name_detector.rb
+++ b/lib/lock_diff/github/repository_name_detector.rb
@@ -1,7 +1,7 @@
 module LockDiff
   module Github
     class RepositoryNameDetector
-      REGEXP = %r!github\.com[/:](.*?)(?:.git)?\z!
+      REGEXP = %r!github\.com[/:](.*?)(?:\.git)?\z!
 
       def initialize(url)
         @url = url


### PR DESCRIPTION
`/.git/` の `/./` が Wildcard として動作していた。


### 😕

```
LockDiff::Github::RepositoryNameDetector.new("https://github.com/floraison/fugit").call # => "floraison/f"
```

### 😃

```
LockDiff::Github::RepositoryNameDetector.new("https://github.com/floraison/fugit").call # => "floraison/fugit"
```