### PR TITLE
exclude #readme from fetched url

### DIFF
--- a/lib/lock_diff/github/repository_name_detector.rb
+++ b/lib/lock_diff/github/repository_name_detector.rb
@@ -9,7 +9,7 @@ module LockDiff
 
       def call
         return unless @url
-        path = @url.match(REGEXP).to_a.last
+        path = @url.match(REGEXP).to_a.last&.split('#')&.first
         return unless path
         repository_name = path.split("/").first(2).join("/")
         repository_name if repository_name.match?(/.+\/.+/)

--- a/spec/lock_diff/github/repository_name_detector_spec.rb
+++ b/spec/lock_diff/github/repository_name_detector_spec.rb
@@ -5,6 +5,7 @@ module LockDiff::Github
     specify do
       expect(RepositoryNameDetector.new("https://github.com/rr/rr").call).to eq 'rr/rr'
       expect(RepositoryNameDetector.new("https://github.com/rr/rr/foo/bar/baz").call).to eq 'rr/rr'
+      expect(RepositoryNameDetector.new("https://github.com/rr/rr/foo#readme").call).to eq 'rrg/rr'
       expect(RepositoryNameDetector.new('https://rubygems.org/gems/rr').call).to eq nil
       expect(RepositoryNameDetector.new(nil).call).to eq nil
     end


### PR DESCRIPTION
## 概要
`user/repo#readme`となっているGemを取得して
```
`raise_invalid_repository!': "postmodern/digest-crc#readme" is invalid as a repository identifier. Use the repo/user (String) format, or the repository ID (Integer), or a hash containing :repo and :user keys. (Octokit::InvalidRepository)
```
^ のエラーを出すので `#`以降を除外するようにしました

## 備考
正規表現苦手なんで力技になりました 🙏 