### PR TITLE
Multiple changelogs

### DIFF
--- a/lib/lock_diff.rb
+++ b/lib/lock_diff.rb
@@ -1,6 +1,7 @@
 require "logger"
 require "forwardable"
 
+require "lock_diff/changelog"
 require "lock_diff/diff_info"
 require "lock_diff/formatter/github_markdown"
 require "lock_diff/gem"

--- a/lib/lock_diff/changelog.rb
+++ b/lib/lock_diff/changelog.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module LockDiff
+  class Changelog
+    attr_reader :url
+
+    def initialize(url)
+      @url = url
+    end
+
+    def name
+      File.basename(@url)
+    end
+  end
+end

--- a/lib/lock_diff/diff_info.rb
+++ b/lib/lock_diff/diff_info.rb
@@ -57,26 +57,16 @@ module LockDiff
       end
     end
 
-    def changelog_url
-      @changelog_url ||= begin
-        ref =
-          case status
-          when UPGRADE, NEW
-            @new_package.ref
-          when DOWNGRADE, DELETE
-            nil # default branch(master)
-          end
+    def changelog
+      return nil if [DOWNGRADE, DELETE].include?(status)
 
-        Github::ChangelogUrlFinder.new(
-          repository: package.repository,
-          repository_url: package.repository_url,
-          ref: ref
-        ).call
-      end
-    end
+      url = Github::ChangelogUrlFinder.new(
+        repository: package.repository,
+        repository_url: package.repository_url,
+        ref: @new_package.ref
+      ).call
 
-    def changelog_name
-      File.basename(changelog_url)
+      Changelog.new(url)
     end
 
     def commits_url

--- a/lib/lock_diff/diff_info.rb
+++ b/lib/lock_diff/diff_info.rb
@@ -57,16 +57,16 @@ module LockDiff
       end
     end
 
-    def changelog
+    def changelogs
       return nil if [DOWNGRADE, DELETE].include?(status)
 
-      url = Github::ChangelogUrlFinder.new(
+      Github::ChangelogUrlFinder.new(
         repository: package.repository,
         repository_url: package.repository_url,
         ref: @new_package.ref
-      ).call
-
-      Changelog.new(url)
+      ).call.map do |url|
+        Changelog.new(url)
+      end
     end
 
     def commits_url

--- a/lib/lock_diff/formatter/github_markdown.rb
+++ b/lib/lock_diff/formatter/github_markdown.rb
@@ -78,14 +78,13 @@ module LockDiff
         end
 
         def changelog
-          if diff_info.changelog_url
-            "[#{diff_info.changelog_name}](#{diff_info.changelog_url})"
+          if diff_info.changelog
+            "[#{diff_info.changelog.name}](#{diff_info.changelog.url})"
           else
             ""
           end
         end
       end
-
     end
   end
 end

--- a/lib/lock_diff/formatter/github_markdown.rb
+++ b/lib/lock_diff/formatter/github_markdown.rb
@@ -41,7 +41,7 @@ module LockDiff
           text << repository
           text << status
           text << commits_text
-          text << changelog
+          text << changelogs
           "| #{text.join(' | ')} |"
         end
 
@@ -77,9 +77,11 @@ module LockDiff
           end
         end
 
-        def changelog
-          if diff_info.changelog
-            "[#{diff_info.changelog.name}](#{diff_info.changelog.url})"
+        def changelogs
+          if diff_info.changelogs
+            diff_info.changelogs.map do |changelog|
+              "[#{changelog.name}](#{changelog.url})"
+            end.join(" ")
           else
             ""
           end

--- a/lib/lock_diff/github/changelog_url_finder.rb
+++ b/lib/lock_diff/github/changelog_url_finder.rb
@@ -17,18 +17,18 @@ module LockDiff
       end
 
       def call
-        find_change_log_url || find_release_url
+        change_log_urls.push(find_release_url).compact
       end
 
       private
 
-      def find_change_log_url
+      def change_log_urls
         Github.client.contents(@repository, ref: @ref).
           select(&:file?).
-          find { |content|
+          select do |content|
             name = content.name.downcase.delete('_')
             CHANGE_LOG_CANDIDATES.any? { |candidate| name.start_with? candidate }
-          }&.html_url
+          end&.map(&:html_url)
       end
 
       def find_release_url


### PR DESCRIPTION
The [graphql gem](https://github.com/rmosolgo/graphql-ruby) has multiple CHANGELOGs:

- [CHANGELOG-pro.md](https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG-pro.md)
- [CHANGELOG-relay.md](https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG-relay.md)
- [CHANGELOG.md](https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG.md)

but lock_diff only displays the first one: [CHANGELOG-pro.md](https://github.com/rmosolgo/graphql-ruby/blob/master/CHANGELOG-pro.md).

![image](https://user-images.githubusercontent.com/1012322/94799436-10a96900-041e-11eb-97fe-71a7fa732abf.png)

This PR makes lock_diff display all available CHANGELOGs.

![image](https://user-images.githubusercontent.com/1012322/94802445-aba44200-0422-11eb-8c51-8787bf547601.png)

Resolves #17