### PR TITLE
Support ruby3

### DIFF
--- a/exe/lock_diff_for_tachikoma
+++ b/exe/lock_diff_for_tachikoma
@@ -4,4 +4,4 @@ require "lock_diff"
 require "lock_diff/cli/option_parser"
 
 options = LockDiff::Cli::OptionParser.parse(ARGV, require_flags: %i(repository))
-LockDiff.run_by_latest_tachikoma(options)
+LockDiff.run_by_latest_tachikoma(**options)


### PR DESCRIPTION
### Summary

* In our project using Ruby 3.0, it began to have an argument error with lock_diff gem. Its error log is:

```
#!/bin/bash -eo pipefail
lock_diff_for_tachikoma -r ${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME} --post-comment=true
/usr/local/bundle/gems/lock_diff-0.5.0/lib/lock_diff.rb:30:in `run_by_la****_tachikoma': wrong number of arguments (given 1, expected 0; required keyword: repository) (ArgumentError)
	from /usr/local/bundle/gems/lock_diff-0.5.0/exe/lock_diff_for_tachikoma:7:in `<top (required)>'
	from /usr/local/bundle/bin/lock_diff_for_tachikoma:23:in `load'
	from /usr/local/bundle/bin/lock_diff_for_tachikoma:23:in `<main>'

Exited with code exit status 1
CircleCI received exit code 1
```

* In Ruby 3.0, positional arguments and keyword arguments will be separated. And I've fixed them.

See at: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/

Please bump version, if you could :pray: