### PR TITLE
Detect CHANGELOGs in docs/ subdirectories

### DIFF
--- a/lib/lock_diff/github/changelog_url_finder.rb
+++ b/lib/lock_diff/github/changelog_url_finder.rb
@@ -18,7 +18,8 @@ module LockDiff
         [
           Directory.new(@repository, @ref),
           Directory.new(@repository, @ref, path: @package_name),
-          Directory.new(@repository, @ref, path: "gems/#{@package_name}")
+          Directory.new(@repository, @ref, path: "gems/#{@package_name}"),
+          Directory.new(@repository, @ref, path: 'docs')
         ]
       end
 


### PR DESCRIPTION
[view_component](https://github.com/github/view_component) has a symlink in its root directory pointing to a CHANGELOG in the docs/ subdirectory.

lock_diff only detects the symlink.

![image](https://user-images.githubusercontent.com/1012322/132844170-fcb4bd2e-9cf1-4be7-8e45-b73d86eddc20.png)

This pull request makes lock_diff display CHANGELOGs stored in the docs/ subdirectory.