### PR TITLE
Support Ruby 3.0.0

### DIFF
--- a/exe/lock_diff
+++ b/exe/lock_diff
@@ -4,4 +4,4 @@ require "lock_diff"
 require "lock_diff/cli/option_parser"
 
 options = LockDiff::Cli::OptionParser.parse(ARGV, require_flags: %i(repository number))
-LockDiff.run(options)
+LockDiff.run(**options)


### PR DESCRIPTION
#48 added Ruby 3.0.0 support to the `lock_diff_for_tachikoma` command, but the same changes weren't made to the `lock_diff` command.

This pull request applies the same changes to the `lock_diff` command.